### PR TITLE
Add Spotify re-authentication logic

### DIFF
--- a/homeassistant/components/spotify/__init__.py
+++ b/homeassistant/components/spotify/__init__.py
@@ -64,14 +64,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_migrate_entry(hass, entry):
     """Handle migration of a previous version config entry."""
     if entry.version == 1:
-        data = {**entry.data}
-        data["token"]["scope"] = " ".join(SPOTIFY_SCOPES)
         hass.async_create_task(
             hass.config_entries.flow.async_init(
-                DOMAIN, context={"source": "reauth"}, data=data,
+                DOMAIN, context={"source": "reauth"}, data=entry.data,
             )
         )
-        return False
 
     return True
 

--- a/homeassistant/components/spotify/__init__.py
+++ b/homeassistant/components/spotify/__init__.py
@@ -61,6 +61,21 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
+async def async_migrate_entry(hass, entry):
+    """Handle migration of a previous version config entry."""
+    if entry.version == 1:
+        data = {**entry.data}
+        data["token"]["scope"] = " ".join(SPOTIFY_SCOPES)
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": "reauth"}, data=data,
+            )
+        )
+        return False
+
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Spotify from a config entry."""
     implementation = await async_get_config_entry_implementation(hass, entry)

--- a/homeassistant/components/spotify/config_flow.py
+++ b/homeassistant/components/spotify/config_flow.py
@@ -1,7 +1,9 @@
 """Config flow for Spotify."""
 import logging
+from typing import Any, Dict, Optional
 
 from spotipy import Spotify
+import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.helpers import config_entry_oauth2_flow
@@ -20,17 +22,22 @@ class SpotifyFlowHandler(
     VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
+    def __init__(self) -> None:
+        """Instantiate config flow."""
+        super().__init__()
+        self.entry: Optional[Dict[str, Any]] = None
+
     @property
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
 
     @property
-    def extra_authorize_data(self) -> dict:
+    def extra_authorize_data(self) -> Dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
         return {"scope": ",".join(SPOTIFY_SCOPES)}
 
-    async def async_oauth_create_entry(self, data: dict) -> dict:
+    async def async_oauth_create_entry(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """Create an entry for Spotify."""
         spotify = Spotify(auth=data["token"]["access_token"])
 
@@ -41,6 +48,9 @@ class SpotifyFlowHandler(
 
         name = data["id"] = current_user["id"]
 
+        if self.entry and self.entry["id"] != current_user["id"]:
+            return self.async_abort(reason="reauth_account_mismatch")
+
         if current_user.get("display_name"):
             name = current_user["display_name"]
         data["name"] = name
@@ -49,6 +59,23 @@ class SpotifyFlowHandler(
 
         return self.async_create_entry(title=name, data=data)
 
-    async def async_step_reauth(self, entry_data):
+    async def async_step_reauth(self, entry: Dict[str, Any]) -> Dict[str, Any]:
         """Perform reauth upon migration of old entries."""
-        return await self.async_oauth_create_entry(entry_data)
+        if entry:
+            self.entry = entry
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Confirm reauth dialog."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                description_placeholders={"account": self.entry["id"]},
+                data_schema=vol.Schema({}),
+                errors={},
+            )
+        return await self.async_step_pick_implementation(
+            user_input={"implementation": self.entry["auth_implementation"]}
+        )

--- a/homeassistant/components/spotify/config_flow.py
+++ b/homeassistant/components/spotify/config_flow.py
@@ -17,6 +17,7 @@ class SpotifyFlowHandler(
     """Config flow to handle Spotify OAuth2 authentication."""
 
     DOMAIN = DOMAIN
+    VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     @property
@@ -47,3 +48,7 @@ class SpotifyFlowHandler(
         await self.async_set_unique_id(current_user["id"])
 
         return self.async_create_entry(title=name, data=data)
+
+    async def async_step_reauth(self, entry_data):
+        """Perform reauth upon migration of old entries."""
+        return await self.async_oauth_create_entry(entry_data)

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -296,7 +296,7 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
     def supported_features(self) -> int:
         """Return the media player features that are supported."""
         if self._me["product"] != "premium":
-            return SUPPORT_SPOTIFY
+            return 0
         return SUPPORT_SPOTIFY
 
     @spotify_exception_handler

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -138,6 +138,9 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
         self._session = session
         self._spotify = spotify
         self._scope_ok = set(session.token["scope"].split(" ")) == set(SPOTIFY_SCOPES)
+        if not self._scope_ok:
+            print(set(session.token["scope"].split(" ")) == set(SPOTIFY_SCOPES))
+            print(set(session.token["scope"].split(" ")), set(SPOTIFY_SCOPES))
 
         self._currently_playing: Optional[dict] = {}
         self._devices: Optional[List[dict]] = []
@@ -296,7 +299,7 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
     def supported_features(self) -> int:
         """Return the media player features that are supported."""
         if self._me["product"] != "premium":
-            return 0
+            return SUPPORT_SPOTIFY
         return SUPPORT_SPOTIFY
 
     @spotify_exception_handler

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -138,9 +138,6 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
         self._session = session
         self._spotify = spotify
         self._scope_ok = set(session.token["scope"].split(" ")) == set(SPOTIFY_SCOPES)
-        if not self._scope_ok:
-            print(set(session.token["scope"].split(" ")) == set(SPOTIFY_SCOPES))
-            print(set(session.token["scope"].split(" ")), set(SPOTIFY_SCOPES))
 
         self._currently_playing: Optional[dict] = {}
         self._devices: Optional[List[dict]] = []

--- a/homeassistant/components/spotify/strings.json
+++ b/homeassistant/components/spotify/strings.json
@@ -1,12 +1,17 @@
 {
   "config": {
     "step": {
-      "pick_implementation": { "title": "Pick Authentication Method" }
+      "pick_implementation": { "title": "Pick Authentication Method" },
+      "reauth_confirm": {
+        "title": "Re-authenticate with Spotify",
+        "description": "The Spotify integration needs to re-authenticate with Spotify for account: {account}"
+      }
     },
     "abort": {
       "already_setup": "You can only configure one Spotify account.",
       "authorize_url_timeout": "Timeout generating authorize url.",
-      "missing_configuration": "The Spotify integration is not configured. Please follow the documentation."
+      "missing_configuration": "The Spotify integration is not configured. Please follow the documentation.",
+      "reauth_account_mismatch": "The Spotify account authenticated with, does not match the account needed re-authentication."
     },
     "create_entry": { "default": "Successfully authenticated with Spotify." }
   }

--- a/tests/components/spotify/test_config_flow.py
+++ b/tests/components/spotify/test_config_flow.py
@@ -85,11 +85,15 @@ async def test_full_flow(hass, aiohttp_client, aioclient_mock, current_request):
     )
 
     with patch("homeassistant.components.spotify.config_flow.Spotify") as spotify_mock:
-        spotify_mock.return_value.current_user.return_value = {"id": "fake_id"}
+        spotify_mock.return_value.current_user.return_value = {
+            "id": "fake_id",
+            "display_name": "frenck",
+        }
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["data"]["auth_implementation"] == DOMAIN
     result["data"]["token"].pop("expires_at")
+    assert result["data"]["name"] == "frenck"
     assert result["data"]["token"] == {
         "refresh_token": "mock-refresh-token",
         "access_token": "mock-access-token",
@@ -138,3 +142,107 @@ async def test_abort_if_spotify_error(
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
     assert result["reason"] == "connection_error"
+
+
+async def test_reauthentication(hass, aiohttp_client, aioclient_mock, current_request):
+    """Test Spotify reauthentication."""
+    old_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=123,
+        version=1,
+        data={"id": "frenck", "auth_implementation": DOMAIN},
+    )
+    old_entry.add_to_hass(hass)
+
+    await setup.async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {CONF_CLIENT_ID: "client", CONF_CLIENT_SECRET: "secret"},
+            "http": {"base_url": "https://example.com"},
+        },
+    )
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].version == 1
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+
+    result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})
+
+    # pylint: disable=protected-access
+    state = config_entry_oauth2_flow._encode_jwt(hass, {"flow_id": result["flow_id"]})
+    client = await aiohttp_client(hass.http.app)
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
+
+    aioclient_mock.post(
+        "https://accounts.spotify.com/api/token",
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": "mock-access-token",
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    with patch("homeassistant.components.spotify.config_flow.Spotify") as spotify_mock:
+        spotify_mock.return_value.current_user.return_value = {"id": "frenck"}
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["data"]["auth_implementation"] == DOMAIN
+    result["data"]["token"].pop("expires_at")
+    assert result["data"]["token"] == {
+        "refresh_token": "mock-refresh-token",
+        "access_token": "mock-access-token",
+        "type": "Bearer",
+        "expires_in": 60,
+    }
+
+
+async def test_reauth_account_mismatch(
+    hass, aiohttp_client, aioclient_mock, current_request
+):
+    """Test Spotify reauthentication with different account."""
+    old_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=123,
+        version=1,
+        data={"id": "frenck", "auth_implementation": DOMAIN},
+    )
+    old_entry.add_to_hass(hass)
+
+    await setup.async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {CONF_CLIENT_ID: "client", CONF_CLIENT_SECRET: "secret"},
+            "http": {"base_url": "https://example.com"},
+        },
+    )
+
+    flows = hass.config_entries.flow.async_progress()
+    result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})
+
+    # pylint: disable=protected-access
+    state = config_entry_oauth2_flow._encode_jwt(hass, {"flow_id": result["flow_id"]})
+    client = await aiohttp_client(hass.http.app)
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
+
+    aioclient_mock.post(
+        "https://accounts.spotify.com/api/token",
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": "mock-access-token",
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    with patch("homeassistant.components.spotify.config_flow.Spotify") as spotify_mock:
+        spotify_mock.return_value.current_user.return_value = {"id": "fake_id"}
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "reauth_account_mismatch"


### PR DESCRIPTION
Adds Spotify re-authentication logic to handle the change in scopes.

Since v1 of the entry is compatible with v2, v1 will continue to load. After re-auth, the integration entry is reloaded.